### PR TITLE
Migrate all unit tests from XCTest to Swift Testing

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# KeyboardManager Package Testing Plan
+
+## Overview
+
+This document outlines the comprehensive testing strategy for the KeyboardManager Swift Package, which has been fully migrated from XCTest to Swift Testing framework for improved performance and maintainability.
+
+## Testing Architecture
+
+### Package Structure
+```
+KeyboardManager/
+├── Package.swift                    # Swift 5.9+, iOS 13+ for Swift Testing
+├── Sources/
+│   └── KeyboardManager/            # Main library code
+└── Tests/
+    └── KeyboardManagerTests/       # All test suites (Swift Testing)
+```
+
+### Test Framework
+- **Framework**: Swift Testing (Apple's modern testing framework)
+- **Minimum Requirements**: iOS 13.0+, Swift 5.9+
+- **Architecture**: Value semantics with `@Suite` structs
+- **Execution**: Parallel by default for optimal performance
+
+## Running Tests
+
+```bash
+xcodebuild test -scheme KeyboardManager -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+
+### Available Test Destinations
+
+**iOS Simulators** (Primary targets):
+- iPhone 17, iPhone 17 Pro, iPhone 17 Pro Max
+- iPhone Air, iPhone 16e
+- iPad Air 11/13-inch (M3), iPad Pro 11/13-inch (M5)
+- iPad (A16), iPad mini (A17 Pro)
+
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
     name: "KeyboardManager",
-    platforms: [.iOS(.v9)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(name: "KeyboardManager", targets: ["KeyboardManager"]),
     ],

--- a/Tests/KeyboardManagerTests/Helpers.swift
+++ b/Tests/KeyboardManagerTests/Helpers.swift
@@ -21,34 +21,120 @@
 // SOFTWARE.
 //
 
-import KeyboardManager
+@testable import KeyboardManager
+import Testing
 import UIKit
+
+// MARK: - TestConfiguration
+
+/// Shared test configuration constants used across multiple test suites
+enum TestConfiguration {
+    static let beginFrame = CGRect(x: 2, y: 6, width: 111, height: 222)
+    static let endFrame = CGRect(x: 1, y: 3, width: 111, height: 222)
+    static let animationDuration: Double = 4.0
+    static let curve = 7
+    static let isLocal = true
+
+    // ScrollView test configuration
+    static let defaultScrollViewInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
+    static let defaultBottomOffset: CGFloat = 20.0
+}
+
+// MARK: - NotificationTestCase
+
+/// Test case data for parameterized notification tests
+struct NotificationTestCase {
+    // MARK: Static Properties
+
+    static let allCases: [NotificationTestCase] = [
+        NotificationTestCase(
+            notificationName: UIResponder.keyboardWillShowNotification,
+            expectedEventType: "willShow",
+            description: "willShow notification",
+        ),
+        NotificationTestCase(
+            notificationName: UIResponder.keyboardDidShowNotification,
+            expectedEventType: "didShow",
+            description: "didShow notification",
+        ),
+        NotificationTestCase(
+            notificationName: UIResponder.keyboardWillHideNotification,
+            expectedEventType: "willHide",
+            description: "willHide notification",
+        ),
+        NotificationTestCase(
+            notificationName: UIResponder.keyboardDidHideNotification,
+            expectedEventType: "didHide",
+            description: "didHide notification",
+        ),
+        NotificationTestCase(
+            notificationName: UIResponder.keyboardWillChangeFrameNotification,
+            expectedEventType: "willFrameChange",
+            description: "willChangeFrame notification",
+        ),
+        NotificationTestCase(
+            notificationName: UIResponder.keyboardDidChangeFrameNotification,
+            expectedEventType: "didFrameChange",
+            description: "didChangeFrame notification",
+        ),
+    ]
+
+    // MARK: Properties
+
+    let notificationName: Notification.Name
+    let expectedEventType: String
+    let description: String
+
+    // MARK: Functions
+
+    /// Checks if the event matches the expected type
+    func matchesEvent(_ event: KeyboardManagerEvent) -> Bool {
+        switch (expectedEventType, event) {
+        case ("willShow", .willShow):
+            true
+        case ("didShow", .didShow):
+            true
+        case ("willHide", .willHide):
+            true
+        case ("didHide", .didHide):
+            true
+        case ("willFrameChange", .willFrameChange):
+            true
+        case ("didFrameChange", .didFrameChange):
+            true
+        default:
+            false
+        }
+    }
+}
+
+// MARK: - Shared Test Helpers
 
 extension KeyboardManagerTests {
     func postTestNotification(name: Notification.Name) {
         notificationCenter.post(name: name, object: nil, userInfo: [
-            UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: endFrame),
-            UIResponder.keyboardFrameBeginUserInfoKey: NSValue(cgRect: beginFrame),
-            UIResponder.keyboardAnimationDurationUserInfoKey: animationDuration,
-            UIResponder.keyboardIsLocalUserInfoKey: isLocal,
-            UIResponder.keyboardAnimationCurveUserInfoKey: curve,
+            UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: TestConfiguration.endFrame),
+            UIResponder.keyboardFrameBeginUserInfoKey: NSValue(cgRect: TestConfiguration.beginFrame),
+            UIResponder.keyboardAnimationDurationUserInfoKey: TestConfiguration.animationDuration,
+            UIResponder.keyboardIsLocalUserInfoKey: TestConfiguration.isLocal,
+            UIResponder.keyboardAnimationCurveUserInfoKey: TestConfiguration.curve,
         ])
     }
 
     func postWrongTestNotification() {
         notificationCenter.post(name: UIResponder.keyboardDidShowNotification, object: nil, userInfo: [
-            UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: endFrame),
+            UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: TestConfiguration.endFrame),
             UIResponder.keyboardAnimationCurveUserInfoKey: 10,
         ])
     }
 
     func compareWithTestData(another data: KeyboardManagerEvent.Data) -> Bool {
-        let isFrameEqual = data.frame.begin == beginFrame &&
-            data.frame.end == endFrame
+        let isFrameEqual = data.frame.begin == TestConfiguration.beginFrame &&
+            data.frame.end == TestConfiguration.endFrame
         return isFrameEqual &&
-            data.animationDuration == animationDuration &&
-            data.animationCurve == curve &&
-            data.isLocal == isLocal
+            data.animationDuration == TestConfiguration.animationDuration &&
+            data.animationCurve == TestConfiguration.curve &&
+            data.isLocal == TestConfiguration.isLocal
     }
 
     func compare(lhs: KeyboardManagerEvent.Data, rhs: KeyboardManagerEvent.Data) -> Bool {
@@ -57,5 +143,75 @@ extension KeyboardManagerTests {
             lhs.isLocal == rhs.isLocal &&
             lhs.frame.begin == rhs.frame.begin &&
             lhs.frame.end == rhs.frame.end
+    }
+
+    /// Creates a configured view with constraint setup for testing
+    func createTestView() -> (view: UIView, parentView: UIView, bottomConstraint: NSLayoutConstraint) {
+        let view = UIView()
+        let parentView = UIView()
+        parentView.addSubview(view)
+        let bottomConstraint = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        return (view, parentView, bottomConstraint)
+    }
+}
+
+extension KeyboardManagerScrollViewTests {
+    func postTestNotification(name: Notification.Name) {
+        notificationCenter.post(name: name, object: nil, userInfo: [
+            UIResponder.keyboardFrameEndUserInfoKey: NSValue(cgRect: TestConfiguration.endFrame),
+            UIResponder.keyboardFrameBeginUserInfoKey: NSValue(cgRect: TestConfiguration.beginFrame),
+            UIResponder.keyboardAnimationDurationUserInfoKey: TestConfiguration.animationDuration,
+            UIResponder.keyboardIsLocalUserInfoKey: TestConfiguration.isLocal,
+            UIResponder.keyboardAnimationCurveUserInfoKey: TestConfiguration.curve,
+        ])
+    }
+
+    /// Creates a configured ScrollView for testing
+    func createTestScrollView() -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.contentInset = TestConfiguration.defaultScrollViewInsets
+        return scrollView
+    }
+}
+
+// MARK: - Shared Test Mocks
+
+/// Shared NotificationCenter mock used across multiple test suites
+class NotificationCenterMock: NotificationCenter, @unchecked Sendable {
+    // MARK: Properties
+
+    var isWillShow: Bool = false
+    var isDidShow: Bool = false
+    var isWillHide: Bool = false
+    var isDidHide: Bool = false
+    var isWillChangeFrame: Bool = false
+    var isDidChangeFrame: Bool = false
+    var isUnsubscribed: Bool = false
+
+    // MARK: Overridden Functions
+
+    override func addObserver(
+        _: Any,
+        selector _: Selector,
+        name aName: NSNotification.Name?,
+        object _: Any?,
+    ) {
+        if case UIResponder.keyboardWillShowNotification = aName! {
+            isWillShow = true
+        } else if case UIResponder.keyboardDidShowNotification = aName! {
+            isDidShow = true
+        } else if case UIResponder.keyboardWillHideNotification = aName! {
+            isWillHide = true
+        } else if case UIResponder.keyboardDidHideNotification = aName! {
+            isDidHide = true
+        } else if case UIResponder.keyboardWillChangeFrameNotification = aName! {
+            isWillChangeFrame = true
+        } else if case UIResponder.keyboardDidChangeFrameNotification = aName! {
+            isDidChangeFrame = true
+        }
+    }
+
+    override func removeObserver(_: Any, name _: NSNotification.Name?, object _: Any?) {
+        isUnsubscribed = true
     }
 }

--- a/Tests/KeyboardManagerTests/KeyboardManager+NotificationCenter.swift
+++ b/Tests/KeyboardManagerTests/KeyboardManager+NotificationCenter.swift
@@ -21,15 +21,13 @@
 // SOFTWARE.
 //
 
-import Foundation
+@testable import KeyboardManager
 import Testing
 import UIKit
 
-@testable import KeyboardManager
-
 // MARK: - KeyboardManagerNotificationCenterTest
 
-@MainActor @Suite(.serialized)
+@MainActor
 class KeyboardManagerNotificationCenterTest {
     // MARK: Properties
 
@@ -78,47 +76,5 @@ class KeyboardManagerNotificationCenterTest {
     @Test func unsubscribe() {
         keyboardManager = nil
         #expect(notificationCenter.isUnsubscribed)
-    }
-}
-
-// MARK: - NotificationCenterMock
-
-// swiftlint:disable force_unwrapping
-class NotificationCenterMock: NotificationCenter {
-    // MARK: Properties
-
-    var isWillShow: Bool = false
-    var isDidShow: Bool = false
-    var isWillHide: Bool = false
-    var isDidHide: Bool = false
-    var isWillChangeFrame: Bool = false
-    var isDidChangeFrame: Bool = false
-    var isUnsubscribed: Bool = false
-
-    // MARK: Overridden Functions
-
-    override func addObserver(
-        _: Any,
-        selector _: Selector,
-        name aName: NSNotification.Name?,
-        object _: Any?,
-    ) {
-        if case UIResponder.keyboardWillShowNotification = aName! {
-            isWillShow = true
-        } else if case UIResponder.keyboardDidShowNotification = aName! {
-            isDidShow = true
-        } else if case UIResponder.keyboardWillHideNotification = aName! {
-            isWillHide = true
-        } else if case UIResponder.keyboardDidHideNotification = aName! {
-            isDidHide = true
-        } else if case UIResponder.keyboardWillChangeFrameNotification = aName! {
-            isWillChangeFrame = true
-        } else if case UIResponder.keyboardDidChangeFrameNotification = aName! {
-            isDidChangeFrame = true
-        }
-    }
-
-    override func removeObserver(_: Any, name _: NSNotification.Name?, object _: Any?) {
-        isUnsubscribed = true
     }
 }

--- a/Tests/KeyboardManagerTests/KeyboardManager+ScrollView.swift
+++ b/Tests/KeyboardManagerTests/KeyboardManager+ScrollView.swift
@@ -22,35 +22,51 @@
 //
 
 @testable import KeyboardManager
+import Testing
 import UIKit
-import XCTest
 
-extension KeyboardManagerTests {
-    func testScrollViewInsetAdjustingAfterKeyboardAppear() {
+@MainActor @Suite("KeyboardManager ScrollView Tests")
+struct KeyboardManagerScrollViewTests {
+    // MARK: Properties
+
+    let notificationCenter: NotificationCenter
+    let keyboardManager: KeyboardManager
+
+    // MARK: Lifecycle
+
+    init() {
+        notificationCenter = NotificationCenter()
+        keyboardManager = KeyboardManager(notificationCenter: notificationCenter)
+    }
+
+    // MARK: Functions
+
+    @Test("ScrollView inset adjusting after keyboard appear")
+    func scrollViewInsetAdjustingAfterKeyboardAppear() {
         // GIVEN
-        let scrollView = UIScrollView()
-        let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
-        scrollView.contentInset = initialInsets
+        let scrollView = createTestScrollView()
+        let initialInsets = TestConfiguration.defaultScrollViewInsets
         // WHEN
         keyboardManager.bindToKeyboardNotifications(scrollView: scrollView)
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset.bottom, initialInsets.bottom + endFrame.height)
+        #expect(scrollView.contentInset.bottom == initialInsets.bottom + TestConfiguration.endFrame.height)
     }
 
-    func testScrollViewInsetAdjustingAfterKeyboardWillChangeFrame() {
+    @Test("ScrollView inset adjusting after keyboard will change frame")
+    func scrollViewInsetAdjustingAfterKeyboardWillChangeFrame() {
         // GIVEN
-        let scrollView = UIScrollView()
-        let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
-        scrollView.contentInset = initialInsets
+        let scrollView = createTestScrollView()
+        let initialInsets = TestConfiguration.defaultScrollViewInsets
         // WHEN
         keyboardManager.bindToKeyboardNotifications(scrollView: scrollView)
         postTestNotification(name: UIResponder.keyboardWillChangeFrameNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset.bottom, initialInsets.bottom + endFrame.height)
+        #expect(scrollView.contentInset.bottom == initialInsets.bottom + TestConfiguration.endFrame.height)
     }
 
-    func testScrollViewInsetAdjustingAfterMultipleKeyboardAppearNotifications() {
+    @Test("ScrollView inset adjusting after multiple keyboard appear notifications")
+    func scrollViewInsetAdjustingAfterMultipleKeyboardAppearNotifications() {
         // GIVEN
         let scrollView = UIScrollView()
         let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
@@ -60,10 +76,11 @@ extension KeyboardManagerTests {
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset.bottom, initialInsets.bottom + endFrame.height)
+        #expect(scrollView.contentInset.bottom == initialInsets.bottom + TestConfiguration.endFrame.height)
     }
 
-    func testScrollViewInsetAdjustingAfterKeyboardWillAppearAndChangeFrameNotifications() {
+    @Test("ScrollView inset adjusting after keyboard will appear and change frame notifications")
+    func scrollViewInsetAdjustingAfterKeyboardWillAppearAndChangeFrameNotifications() {
         // GIVEN
         let scrollView = UIScrollView()
         let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
@@ -73,10 +90,11 @@ extension KeyboardManagerTests {
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         postTestNotification(name: UIResponder.keyboardWillChangeFrameNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset.bottom, initialInsets.bottom + endFrame.height)
+        #expect(scrollView.contentInset.bottom == initialInsets.bottom + TestConfiguration.endFrame.height)
     }
 
-    func testResetBottomInsetAfterKeyboardDisappear() {
+    @Test("Reset bottom inset after keyboard disappear")
+    func resetBottomInsetAfterKeyboardDisappear() {
         // GIVEN
         let scrollView = UIScrollView()
         let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
@@ -86,10 +104,11 @@ extension KeyboardManagerTests {
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         postTestNotification(name: UIResponder.keyboardWillHideNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset, initialInsets)
+        #expect(scrollView.contentInset == initialInsets)
     }
 
-    func testResetBottomInsetAfterMultipleKeyboardDisappearNotifications() {
+    @Test("Reset bottom inset after multiple keyboard disappear notifications")
+    func resetBottomInsetAfterMultipleKeyboardDisappearNotifications() {
         // GIVEN
         let scrollView = UIScrollView()
         let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
@@ -100,10 +119,11 @@ extension KeyboardManagerTests {
         postTestNotification(name: UIResponder.keyboardWillHideNotification)
         postTestNotification(name: UIResponder.keyboardWillHideNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset, initialInsets)
+        #expect(scrollView.contentInset == initialInsets)
     }
 
-    func testScrollViewShouldNotChangeInsetsOnDidShowNotification() {
+    @Test("ScrollView should not change insets on didShow notification")
+    func scrollViewShouldNotChangeInsetsOnDidShowNotification() {
         // GIVEN
         let scrollView = UIScrollView()
         let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
@@ -112,10 +132,11 @@ extension KeyboardManagerTests {
         keyboardManager.bindToKeyboardNotifications(scrollView: scrollView)
         postTestNotification(name: UIResponder.keyboardDidShowNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset, initialInsets)
+        #expect(scrollView.contentInset == initialInsets)
     }
 
-    func testScrollViewShouldNotChangeInsetsOnDidChangeFrameNotification() {
+    @Test("ScrollView should not change insets on didChangeFrame notification")
+    func scrollViewShouldNotChangeInsetsOnDidChangeFrameNotification() {
         // GIVEN
         let scrollView = UIScrollView()
         let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
@@ -124,10 +145,11 @@ extension KeyboardManagerTests {
         keyboardManager.bindToKeyboardNotifications(scrollView: scrollView)
         postTestNotification(name: UIResponder.keyboardDidChangeFrameNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset, initialInsets)
+        #expect(scrollView.contentInset == initialInsets)
     }
 
-    func testScrollViewShouldNotChangeInsetsOnDidHideNotification() {
+    @Test("ScrollView should not change insets on didHide notification")
+    func scrollViewShouldNotChangeInsetsOnDidHideNotification() {
         // GIVEN
         let scrollView = UIScrollView()
         let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
@@ -136,6 +158,6 @@ extension KeyboardManagerTests {
         keyboardManager.bindToKeyboardNotifications(scrollView: scrollView)
         postTestNotification(name: UIResponder.keyboardWillHideNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset, initialInsets)
+        #expect(scrollView.contentInset == initialInsets)
     }
 }

--- a/Tests/KeyboardManagerTests/KeyboardManagerTests.swift
+++ b/Tests/KeyboardManagerTests/KeyboardManagerTests.swift
@@ -22,298 +22,310 @@
 //
 
 @testable import KeyboardManager
+import Testing
 import UIKit
-import XCTest
 
-class KeyboardManagerTests: XCTestCase {
+@MainActor @Suite("KeyboardManager Tests")
+struct KeyboardManagerTests {
     // MARK: Properties
 
-    let beginFrame = CGRect(x: 2, y: 6, width: 111, height: 222)
-    let endFrame = CGRect(x: 1, y: 3, width: 111, height: 222)
-    let animationDuration: Double = 4.0
-    let curve = 7
-    let isLocal = true
+    let notificationCenter: NotificationCenter
 
-    var notificationCenter: NotificationCenter!
-    var keyboardManager: KeyboardManager!
-    var observerToken: KeyboardObserverToken?
+    // MARK: Lifecycle
 
-    // MARK: Overridden Functions
-
-    override func setUp() {
-        super.setUp()
+    init() {
         notificationCenter = NotificationCenter()
-        keyboardManager = KeyboardManager(notificationCenter: notificationCenter)
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        keyboardManager = nil
-        notificationCenter = nil
-        observerToken = nil
     }
 
     // MARK: Functions
 
-    func testCallClosureAfterWillAppearNotification() {
+    @Test("Keyboard notification events", arguments: NotificationTestCase.allCases)
+    func keyboardNotificationEvents(testCase: NotificationTestCase) {
         var isTriggered = false
-        observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
-            if case let .willShow(data) = event,
-               self.compareWithTestData(another: data)
-            {
+        let observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
+            if testCase.matchesEvent(event), compareWithTestData(another: event.data) {
                 isTriggered = true
             }
         }
-        postTestNotification(name: UIResponder.keyboardWillShowNotification)
-        XCTAssertTrue(isTriggered)
+        _ = observerToken // Avoid unused variable warning
+        postTestNotification(name: testCase.notificationName)
+        #expect(isTriggered, "Failed to trigger \(testCase.description)")
     }
 
-    func testCallClosureAfterDidAppearNotification() {
+    @Test("Call closure after didShow notification")
+    func callClosureAfterDidAppearNotification() {
         var isTriggered = false
-        observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
+        let observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
             if case let .didShow(data) = event,
-               self.compareWithTestData(another: data)
+               compareWithTestData(another: data)
             {
                 isTriggered = true
             }
         }
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardDidShowNotification)
-        XCTAssertTrue(isTriggered)
+        #expect(isTriggered)
     }
 
-    func testCallClosureAfterWillHideNotification() {
+    @Test("Call closure after willHide notification")
+    func callClosureAfterWillHideNotification() {
         var isTriggered = false
-        observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
+        let observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
             if case let .willHide(data) = event,
-               self.compareWithTestData(another: data)
+               compareWithTestData(another: data)
             {
                 isTriggered = true
             }
         }
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardWillHideNotification)
-        XCTAssertTrue(isTriggered)
+        #expect(isTriggered)
     }
 
-    func testCallClosureAfterDidHideNotification() {
+    @Test("Call closure after didHide notification")
+    func callClosureAfterDidHideNotification() {
         var isTriggered = false
-        observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
+        let observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
             if case let .didHide(data) = event,
-               self.compareWithTestData(another: data)
+               compareWithTestData(another: data)
             {
                 isTriggered = true
             }
         }
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardDidHideNotification)
-        XCTAssertTrue(isTriggered)
+        #expect(isTriggered)
     }
 
-    func testCallClosureAfterWillChangeFrameNotification() {
+    @Test("Call closure after willChangeFrame notification")
+    func callClosureAfterWillChangeFrameNotification() {
         var isTriggered = false
-        observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
+        let observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
             if case let .willFrameChange(data) = event,
-               self.compareWithTestData(another: data)
+               compareWithTestData(another: data)
             {
                 isTriggered = true
             }
         }
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardWillChangeFrameNotification)
-        XCTAssertTrue(isTriggered)
+        #expect(isTriggered)
     }
 
-    func testCallClosureAfterDidChangeFrameNotification() {
+    @Test("Call closure after didChangeFrame notification")
+    func callClosureAfterDidChangeFrameNotification() {
         var isTriggered = false
-        observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
+        let observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
             if case let .didFrameChange(data) = event,
-               self.compareWithTestData(another: data)
+               compareWithTestData(another: data)
             {
                 isTriggered = true
             }
         }
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardDidChangeFrameNotification)
-        XCTAssertTrue(isTriggered)
+        #expect(isTriggered)
     }
 
-    func testNullObjectAfterWrongFormatNotification() {
-        let expectation = expectation(description: "wrong notification expectation")
-        observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
-            let data = event.data
-            let nullObject = KeyboardManagerEvent.Data.null()
-            XCTAssertTrue(self.compare(lhs: data, rhs: nullObject))
-            expectation.fulfill()
+    @Test("Null object after wrong format notification")
+    func nullObjectAfterWrongFormatNotification() async {
+        await confirmation("wrong notification expectation") { confirm in
+            let observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
+                let data = event.data
+                let nullObject = KeyboardManagerEvent.Data.null()
+                #expect(compare(lhs: data, rhs: nullObject))
+                confirm()
+            }
+            _ = observerToken // Avoid unused variable warning
+            postWrongTestNotification()
         }
-        postWrongTestNotification()
-        waitForExpectations(timeout: 5)
     }
 
-    func testNullObjectAfterNotificationWithoutUserDictionary() {
-        let expectation = expectation(description: "null object expectation")
-        observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
-            let data = event.data
-            let nullObject = KeyboardManagerEvent.Data.null()
-            XCTAssertTrue(self.compare(lhs: data, rhs: nullObject))
-            expectation.fulfill()
+    @Test("Null object after notification without user dictionary")
+    func nullObjectAfterNotificationWithoutUserDictionary() async {
+        await confirmation("null object expectation") { confirm in
+            let observerToken = KeyboardObserver.addObserver(notificationCenter) { event in
+                let data = event.data
+                let nullObject = KeyboardManagerEvent.Data.null()
+                #expect(compare(lhs: data, rhs: nullObject))
+                confirm()
+            }
+            _ = observerToken // Avoid unused variable warning
+            notificationCenter.post(name: UIResponder.keyboardDidShowNotification, object: nil)
         }
-        notificationCenter.post(name: UIResponder.keyboardDidShowNotification, object: nil)
-        waitForExpectations(timeout: 5)
     }
 
-    func testViewShouldChangeBottomInsetAfterKeyboardsWillAppear() {
+    @Test("View should change bottom inset after keyboard will appear")
+    func viewShouldChangeBottomInsetAfterKeyboardsWillAppear() {
         // GIVEN
-        let view = UIView()
-        let parentView = UIView()
-        parentView.addSubview(view)
-        let bottomConstrain = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        let bottomOffset: CGFloat = 20.0
+        let (view, _, bottomConstraint) = createTestView()
+        let bottomOffset = TestConfiguration.defaultBottomOffset
         // WHEN
-        observerToken = KeyboardObserver.addObserver(
+        let observerToken = KeyboardObserver.addObserver(
             notificationCenter,
             superview: view,
-            bottomConstraint: bottomConstrain,
+            bottomConstraint: bottomConstraint,
             bottomOffset: bottomOffset,
         )
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         // THEN
-        XCTAssertEqual(bottomConstrain.constant, -endFrame.height)
+        #expect(bottomConstraint.constant == -TestConfiguration.endFrame.height)
     }
 
-    func testViewShouldChangeBottomInsetAfterKeyboardWillChangeFrame() {
+    @Test("View should change bottom inset after keyboard will change frame")
+    func viewShouldChangeBottomInsetAfterKeyboardWillChangeFrame() {
         // GIVEN
         let view = UIView()
         let parentView = UIView()
         parentView.addSubview(view)
-        let bottomConstrain = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let bottomConstraint = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         let bottomOffset: CGFloat = 20.0
         // WHEN
-        observerToken = KeyboardObserver.addObserver(
+        let observerToken = KeyboardObserver.addObserver(
             notificationCenter,
             superview: view,
-            bottomConstraint: bottomConstrain,
+            bottomConstraint: bottomConstraint,
             bottomOffset: bottomOffset,
         )
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardWillChangeFrameNotification)
         // THEN
-        XCTAssertEqual(bottomConstrain.constant, -endFrame.height)
+        #expect(bottomConstraint.constant == -TestConfiguration.endFrame.height)
     }
 
-    func testViewShouldChangeBottomInsetOnceAfterMultipleKeyboardsWillAppear() {
+    @Test("View should change bottom inset once after multiple keyboards will appear")
+    func viewShouldChangeBottomInsetOnceAfterMultipleKeyboardsWillAppear() {
         // GIVEN
         let view = UIView()
         let parentView = UIView()
         parentView.addSubview(view)
-        let bottomConstrain = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let bottomConstraint = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         let bottomOffset: CGFloat = 20.0
         // WHEN
-        observerToken = KeyboardObserver.addObserver(
+        let observerToken = KeyboardObserver.addObserver(
             notificationCenter,
             superview: view,
-            bottomConstraint: bottomConstrain,
+            bottomConstraint: bottomConstraint,
             bottomOffset: bottomOffset,
         )
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         // THEN
-        XCTAssertEqual(bottomConstrain.constant, -endFrame.height)
+        #expect(bottomConstraint.constant == -TestConfiguration.endFrame.height)
     }
 
-    func testViewShouldChangeBottomInsetAfterKeyboardsWillDisappear() {
+    @Test("View should change bottom inset after keyboards will disappear")
+    func viewShouldChangeBottomInsetAfterKeyboardsWillDisappear() {
         // GIVEN
         let view = UIView()
         let parentView = UIView()
         parentView.addSubview(view)
-        let bottomConstrain = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let bottomConstraint = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         let bottomOffset: CGFloat = 20.0
         // WHEN
-        observerToken = KeyboardObserver.addObserver(
+        let observerToken = KeyboardObserver.addObserver(
             notificationCenter,
             superview: view,
-            bottomConstraint: bottomConstrain,
+            bottomConstraint: bottomConstraint,
             bottomOffset: bottomOffset,
         )
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardWillHideNotification)
         // THEN
-        XCTAssertEqual(bottomConstrain.constant, -bottomOffset)
+        #expect(bottomConstraint.constant == -bottomOffset)
     }
 
-    func testViewShouldChangeBottomInsetOnceAfterMultipleKeyboardsWillDisappear() {
+    @Test("View should change bottom inset once after multiple keyboards will disappear")
+    func viewShouldChangeBottomInsetOnceAfterMultipleKeyboardsWillDisappear() {
         // GIVEN
         let view = UIView()
         let parentView = UIView()
         parentView.addSubview(view)
-        let bottomConstrain = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let bottomConstraint = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         let bottomOffset: CGFloat = 20.0
         // WHEN
-        observerToken = KeyboardObserver.addObserver(
+        let observerToken = KeyboardObserver.addObserver(
             notificationCenter,
             superview: view,
-            bottomConstraint: bottomConstrain,
+            bottomConstraint: bottomConstraint,
             bottomOffset: bottomOffset,
         )
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardWillHideNotification)
         postTestNotification(name: UIResponder.keyboardWillHideNotification)
         postTestNotification(name: UIResponder.keyboardWillHideNotification)
         // THEN
-        XCTAssertEqual(bottomConstrain.constant, -bottomOffset)
+        #expect(bottomConstraint.constant == -bottomOffset)
     }
 
-    func testViewShouldNotChangeBottomInsetAfterKeyboardsDidAppear() {
+    @Test("View should not change bottom inset after keyboards did appear")
+    func viewShouldNotChangeBottomInsetAfterKeyboardsDidAppear() {
         // GIVEN
         let view = UIView()
         let parentView = UIView()
         parentView.addSubview(view)
-        let bottomConstrain = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let bottomConstraint = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         let bottomOffset: CGFloat = 20.0
         // WHEN
-        observerToken = KeyboardObserver.addObserver(
+        let observerToken = KeyboardObserver.addObserver(
             notificationCenter,
             superview: view,
-            bottomConstraint: bottomConstrain,
+            bottomConstraint: bottomConstraint,
             bottomOffset: bottomOffset,
         )
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardDidShowNotification)
         // THEN
-        XCTAssertEqual(bottomConstrain.constant, 0)
+        #expect(bottomConstraint.constant == 0)
     }
 
-    func testViewShouldNotChangeBottomInsetAfterKeyboardsDidDisappear() {
+    @Test("View should not change bottom inset after keyboards did disappear")
+    func viewShouldNotChangeBottomInsetAfterKeyboardsDidDisappear() {
         // GIVEN
         let view = UIView()
         let parentView = UIView()
         parentView.addSubview(view)
-        let bottomConstrain = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let bottomConstraint = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         let bottomOffset: CGFloat = 20.0
         // WHEN
-        observerToken = KeyboardObserver.addObserver(
+        let observerToken = KeyboardObserver.addObserver(
             notificationCenter,
             superview: view,
-            bottomConstraint: bottomConstrain,
+            bottomConstraint: bottomConstraint,
             bottomOffset: bottomOffset,
         )
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardDidHideNotification)
         // THEN
-        XCTAssertEqual(bottomConstrain.constant, 0)
+        #expect(bottomConstraint.constant == 0)
     }
 
-    func testViewShouldNotChangeBottomInsetAfterKeyboardsDidChangeFrame() {
+    @Test("View should not change bottom inset after keyboards did change frame")
+    func viewShouldNotChangeBottomInsetAfterKeyboardsDidChangeFrame() {
         // GIVEN
         let view = UIView()
         let parentView = UIView()
         parentView.addSubview(view)
-        let bottomConstrain = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let bottomConstraint = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         let bottomOffset: CGFloat = 20.0
         // WHEN
-        observerToken = KeyboardObserver.addObserver(
+        let observerToken = KeyboardObserver.addObserver(
             notificationCenter,
             superview: view,
-            bottomConstraint: bottomConstrain,
+            bottomConstraint: bottomConstraint,
             bottomOffset: bottomOffset,
         )
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardDidChangeFrameNotification)
         // THEN
-        XCTAssertEqual(bottomConstrain.constant, 0)
+        #expect(bottomConstraint.constant == 0)
     }
 
-    func testViewShouldNotCancelScrollViewBindingWhileViewBindingActivated() {
+    @Test("View should not cancel scroll view binding while view binding activated")
+    func viewShouldNotCancelScrollViewBindingWhileViewBindingActivated() {
         // GIVEN
         let scrollView = UIScrollView()
         let initialInsets = UIEdgeInsets(top: 10, left: 11, bottom: 12, right: 13)
@@ -322,28 +334,35 @@ class KeyboardManagerTests: XCTestCase {
         let view = UIView()
         let parentView = UIView()
         parentView.addSubview(view)
-        let bottomConstrain = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        let bottomConstraint = parentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         let bottomOffset: CGFloat = 20.0
 
         // WHEN
         let anotherToken = KeyboardObserver.addObserver(notificationCenter, scrollView: scrollView)
-        anotherToken.doNothing()
-        observerToken = KeyboardObserver.addObserver(
+        _ = anotherToken // Avoid unused variable warning
+        let observerToken = KeyboardObserver.addObserver(
             notificationCenter,
             superview: view,
-            bottomConstraint: bottomConstrain,
+            bottomConstraint: bottomConstraint,
             bottomOffset: bottomOffset,
         )
+        _ = observerToken // Avoid unused variable warning
         postTestNotification(name: UIResponder.keyboardWillShowNotification)
         // THEN
-        XCTAssertEqual(scrollView.contentInset.bottom, initialInsets.bottom + endFrame.height)
-        XCTAssertEqual(bottomConstrain.constant, -endFrame.height)
+        #expect(scrollView.contentInset.bottom == initialInsets.bottom + TestConfiguration.endFrame.height)
+        #expect(bottomConstraint.constant == -TestConfiguration.endFrame.height)
     }
 
-    func testDataPropertyInEventModel() {
+    @Test("Data property in event model")
+    func dataPropertyInEventModel() {
         // GIVEN
-        let frame = KeyboardManagerEvent.Frame(begin: beginFrame, end: endFrame)
-        let data = KeyboardManagerEvent.Data(frame: frame, animationCurve: curve, animationDuration: animationDuration, isLocal: isLocal)
+        let frame = KeyboardManagerEvent.Frame(begin: TestConfiguration.beginFrame, end: TestConfiguration.endFrame)
+        let data = KeyboardManagerEvent.Data(
+            frame: frame,
+            animationCurve: TestConfiguration.curve,
+            animationDuration: TestConfiguration.animationDuration,
+            isLocal: TestConfiguration.isLocal,
+        )
         // WHEN
         let didHideEvent = KeyboardManagerEvent.didHide(data)
         let willHideEvent = KeyboardManagerEvent.willHide(data)
@@ -355,9 +374,9 @@ class KeyboardManagerTests: XCTestCase {
         let willShowSuccess = compareWithTestData(another: willShowEvent.data)
         let didShowSuccess = compareWithTestData(another: didShowEvent.data)
         // THEN
-        XCTAssertTrue(didHideSuccess)
-        XCTAssertTrue(willHideSuccess)
-        XCTAssertTrue(willShowSuccess)
-        XCTAssertTrue(didShowSuccess)
+        #expect(didHideSuccess)
+        #expect(willHideSuccess)
+        #expect(willShowSuccess)
+        #expect(didShowSuccess)
     }
 }

--- a/Tests/KeyboardManagerTests/KeyboardObserverTests.swift
+++ b/Tests/KeyboardManagerTests/KeyboardObserverTests.swift
@@ -21,31 +21,15 @@
 // SOFTWARE.
 //
 
-import Foundation
 @testable import KeyboardManager
 import Testing
 
 // MARK: - KeyboardObserverTests
 
-@MainActor @Suite(.serialized)
-class KeyboardObserverTests {
-    // MARK: Properties
-
-    var notificationCenter: NotificationCenterMock!
-
-    // MARK: Lifecycle
-
-    init() {
-        notificationCenter = NotificationCenterMock()
-    }
-
-    deinit {
-        notificationCenter = nil
-    }
-
-    // MARK: Functions
-
+@MainActor
+struct KeyboardObserverTests {
     @Test func keyboardObserverSubscription() {
+        let notificationCenter = NotificationCenterMock()
         _ = KeyboardObserver.addObserver(notificationCenter) { _ in }
         #expect(notificationCenter.isWillShow)
         #expect(notificationCenter.isDidShow)
@@ -56,15 +40,11 @@ class KeyboardObserverTests {
     }
 
     @Test func keyboardObserverUnsubscriptionOnDeallocation() {
+        let notificationCenter = NotificationCenterMock()
         var token: KeyboardObserverToken? = KeyboardObserver.addObserver(notificationCenter) { _ in }
-        token?.doNothing()
+        _ = token // Avoid unused variable warning
         #expect(!notificationCenter.isUnsubscribed)
         token = nil
         #expect(notificationCenter.isUnsubscribed)
     }
-}
-
-extension KeyboardObserverToken {
-    /// this method does nothing to remove warning in L52
-    func doNothing() {}
 }

--- a/Tests/KeyboardManagerTests/LastKeyboardEventStorageTests.swift
+++ b/Tests/KeyboardManagerTests/LastKeyboardEventStorageTests.swift
@@ -21,15 +21,14 @@
 // SOFTWARE.
 //
 
-import Foundation
 @testable import KeyboardManager
 import Testing
 
-@MainActor @Suite(.serialized)
-class LastKeyboardEventStorageTests {
+@MainActor
+struct LastKeyboardEventStorageTests {
     // MARK: Properties
 
-    var notificationCenter: NotificationCenterMock!
+    var notificationCenter: NotificationCenterMock
     var storage: LastKeyboardEventStorage!
 
     // MARK: Lifecycle
@@ -37,11 +36,6 @@ class LastKeyboardEventStorageTests {
     init() {
         notificationCenter = NotificationCenterMock()
         storage = LastKeyboardEventStorage(notificationCenter: notificationCenter)
-    }
-
-    deinit {
-        storage = nil
-        notificationCenter = nil
     }
 
     // MARK: Functions
@@ -55,7 +49,7 @@ class LastKeyboardEventStorageTests {
         #expect(notificationCenter.isDidChangeFrame)
     }
 
-    @Test func lastEventStorageShouldUnsubscribeOnDealloc() {
+    @Test mutating func lastEventStorageShouldUnsubscribeOnDealloc() {
         #expect(!notificationCenter.isUnsubscribed)
         storage = nil
         #expect(notificationCenter.isUnsubscribed)


### PR DESCRIPTION
- Updated Package.swift to require iOS 13+ and Swift 5.9 for Swift Testing support
- Migrated KeyboardManagerTests.swift from XCTestCase class to @Suite struct
- Converted all XCTAssert* calls to #expect macros
- Migrated KeyboardManager+ScrollView.swift extension tests to standalone @Suite
- Updated async expectations from XCTestExpectation to Swift Testing confirmation()
- Fixed mutable state issues by using local observer tokens instead of struct properties
- Preserved all test logic while modernizing syntax and patterns
- All tests now use Swift Testing framework exclusively for better performance